### PR TITLE
Wrapping Inner Container of "user-card" with Anchor Tag, Small "Chirp" Component Creation, Validation Changes

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -14,8 +14,15 @@ use Illuminate\Http\RedirectResponse;
 class CommentController extends Controller
 {
 
-    public function store(Chirp $chirp)
+    public function store(Request $request, Chirp $chirp): RedirectResponse
     {
+
+        //Functions as comments are not created, but error messages still need to be returned.
+
+        $request->validate([
+            'content' => 'required|string|max:255',
+        ]);
+
         Comment::create([
             'user_id' => Auth::user()->id,
             'chirp_id' => $chirp->id,

--- a/app/View/Components/SmallChirp.php
+++ b/app/View/Components/SmallChirp.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class SmallChirp extends Component
+{
+    /**
+     * Create a new component instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.small-chirp');
+    }
+}

--- a/app/View/Components/UserCard.php
+++ b/app/View/Components/UserCard.php
@@ -41,7 +41,7 @@ class UserCard extends Component
     {
         if ($firstChirp !== null ){
             $firstChirp = $firstChirp->created_at;
-            $firstChirp =  date("l, F d, Y", strtotime($firstChirp));
+            $firstChirp =  date("M jS, Y", strtotime($firstChirp));
             return $firstChirp;
         } else {
             return $firstChirp;

--- a/resources/views/chirps/latest.blade.php
+++ b/resources/views/chirps/latest.blade.php
@@ -1,22 +1,7 @@
 <x-app-layout>
-<div class="mt-6 shadow-sm rounded-lg">
-            @foreach ($chirps as $chirp)
-                <div class="p-6 flex space-x-2">
-                    <div class="flex-1">
-                        <div class="flex justify-between items-center">
-                            <div>
-                                <a href="/user/{{ $chirp->user->name }}">
-                                <img width="50" height="50" src=" {{$chirp->user->profile_image_url}}">
-                                </a>
-                                <a href="/user/{{ $chirp->user->name }}">
-                                <span class="text-gray-800">{{ $chirp->user->name }}</span>
-                                </a>
-                                <small class="ml-2 text-sm text-gray-600">{{ $chirp->created_at->format('j M Y, g:i a') }}</small>
-                            </div>
-                        </div>
-                        <p class="mt-4 text-lg text-gray-900">{{ $chirp->message }}</p>
-                    </div>
-                </div>
-            @endforeach
-        </div>
-</x-app-layout>
+    <div class="p-6" style="display:flex; flex-direction:column;width:550px;margin-top:2rem;">
+       @foreach ($chirps as $chirp)
+            <x-chirps-small :chirp="$chirp"/>
+       @endforeach
+    </div>
+ </x-app-layout>

--- a/resources/views/chirps/latest.blade.php
+++ b/resources/views/chirps/latest.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <div class="p-6" style="display:flex; flex-direction:column;width:550px;margin-top:2rem;">
        @foreach ($chirps as $chirp)
-            <x-chirps-small :chirp="$chirp"/>
+            <x-small-chirp :chirp="$chirp"/>
        @endforeach
     </div>
  </x-app-layout>

--- a/resources/views/components/chirps-small.blade.php
+++ b/resources/views/components/chirps-small.blade.php
@@ -1,0 +1,14 @@
+<div class="p-6 flex space-x-2 bg-white rounded-lg shadow-lg" style="width:400px;margin:auto; margin-bottom:1rem;">
+    <div class="flex-1">
+        <div class="flex" style="flex-direction: row;">
+                <div style="width:100px;margin:10px;">
+                    <img width="50" height="50" src=" {{$chirp->user->profile_image_url}}">
+                    <span class="text-gray-800">{{ $chirp->user->name }}</span>
+                </div>
+                <div style="align-items:left;width:200px;">
+                    <p class="mt-4 text-m text-gray-600 ml-2">" {{ $chirp->message }} "</p>
+                    <small class="ml-2 text-sm text-gray-500">{{ $chirp->created_at->format('j M Y, g:i a') }}</small>
+                 </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/components/small-chirp.blade.php
+++ b/resources/views/components/small-chirp.blade.php
@@ -1,3 +1,5 @@
+@props(['chirp'])
+
 <div class="p-6 flex space-x-2 bg-white rounded-lg shadow-lg" style="width:400px;margin:auto; margin-bottom:1rem;">
     <div class="flex-1">
         <div class="flex" style="flex-direction: row;">
@@ -7,7 +9,7 @@
                 </div>
                 <div style="align-items:left;width:200px;">
                     <p class="mt-4 text-m text-gray-600 ml-2">" {{ $chirp->message }} "</p>
-                    <small class="ml-2 text-sm text-gray-500">{{ $chirp->created_at->format('j M Y, g:i a') }}</small>
+                    <small class="ml-2 text-sm text-gray-500">{{ $chirp->created_at->format('M jS, Y') }}</small>
                  </div>
         </div>
     </div>

--- a/resources/views/components/user-card.blade.php
+++ b/resources/views/components/user-card.blade.php
@@ -1,14 +1,16 @@
 <div class="p-6 flex space-x-2 shadow-md rounded-lg" style="background-color:white;margin:1rem;width:400px;">
     <div class="flex-1" style="width:300px;outline:2px dashed #26A7DE;border-radius:.3rem;padding:2rem;">
+
+        <a href="/user/{{ $user->name }}">
         <div class="flex p-1">
             <div>
-                <a href="/user/{{ $user->name }}">
-                    <div class="rounded-lg" style="width:100px;height:100px;background-image:url('{{$user->profile_image_url}}');background-position:center;background-size:cover;"></div>
-                </a>
-            </div>
 
+                    <div class="rounded-lg" style="width:100px;height:100px;background-image:url('{{$user->profile_image_url}}');background-position:center;background-size:cover;">
+                    </div>
+
+            </div>
             <div style="padding-left:1rem;width:250px;">
-                <a  class="text-xl" href="/user/{{ $user->name }}">{{ $user->name }}</a>
+                <p class="text-l">{{ $user->name }}</p>
                 <div class="pt-1">
                     @if ($firstChirpDate == null)
                         <p class="text-gray-600 text-sm">Just Hatched!</p>
@@ -21,5 +23,6 @@
             </div>
 
         </div>
+        </a>
     </div>
 </div>

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -6,7 +6,7 @@
         </div>
 
             @foreach ($user->chirps as $chirp)
-                <x-chirps-small :chirp="$chirp"/>
+                <x-small-chirp :chirp="$chirp"/>
             @endforeach
     </div>
 {{-- End of View for Chirper User Profile --}}

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -4,19 +4,9 @@
         <div class="p-6 flex space-x-2">
             <x-user-card :user="$user"/>
         </div>
+
             @foreach ($user->chirps as $chirp)
-                <div class="p-6 flex space-x-2">
-                    <div class="flex-1">
-                        <div class="flex justify-between items-center">
-                            <div>
-                                <img width="50" height="50" src=" {{$chirp->user->profile_image_url}}">
-                                <span class="text-gray-800">{{ $chirp->user->name }}</span>
-                                <small class="ml-2 text-sm text-gray-600">{{ $chirp->created_at->format('j M Y, g:i a') }}</small>
-                            </div>
-                        </div>
-                        <p class="mt-4 text-lg text-gray-900">{{ $chirp->message }}</p>
-                    </div>
-                </div>
+                <x-chirps-small :chirp="$chirp"/>
             @endforeach
     </div>
 {{-- End of View for Chirper User Profile --}}


### PR DESCRIPTION
Inner Container of 'user-card' is now wrapped in an anchor tag, recent and user-profile chirps pages now share a 'chirps-small' component, and server-side validation -sans error messages has been included for comments