### PR TITLE
Image Service and Copy Image URLs Command

### DIFF
--- a/app/Console/Commands/CopyProfileImageUrls.php
+++ b/app/Console/Commands/CopyProfileImageUrls.php
@@ -54,7 +54,12 @@ class CopyProfileImageUrls extends Command
 
             if ($url){
 
-                $this->imageService->downloadImageFromUrl($url, $user_id);
+                $filename = pathinfo($url, PATHINFO_FILENAME);
+                $folder = "user-{$user_id}";
+                $path = $this->imageService->downloadImageFromUrl($url, $filename, $folder);
+
+                $this->imageService->addUserImageRecord($user_id, $path);
+
             }
 
         }

--- a/app/Console/Commands/CopyProfileImageUrls.php
+++ b/app/Console/Commands/CopyProfileImageUrls.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Service\ImageService;
+
+class CopyProfileImageUrls extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:copy-profile-image-urls';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Takes all profile image url values in the profile_image_url column of the Users table, iterates through and downloads the images, assigns each image a unique filename connected to the user id, and creates the records in the Images table.';
+
+    /**
+     * @var ImageService
+     */
+    protected $imageService;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param ImageService $imageService
+     */
+    public function __construct(ImageService $imageService)
+    {
+        parent::__construct();
+        $this->imageService = $imageService;
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('Copying profile image URLs...');
+
+        $this->imageService->copyAllUserProfileImageUrls();
+
+        $this->info('All profile image urls on Users table are now downloaded, with entries added to the Images table.');
+    }
+}

--- a/app/Console/Commands/CopyProfileImageUrls.php
+++ b/app/Console/Commands/CopyProfileImageUrls.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use App\Service\ImageService;
+use App\Models\User;
 
 class CopyProfileImageUrls extends Command
 {
@@ -44,7 +45,19 @@ class CopyProfileImageUrls extends Command
     {
         $this->info('Copying profile image URLs...');
 
-        $this->imageService->copyAllUserProfileImageUrls();
+        $profileImageUrlWithIds = User::all()->map->only('id', 'profile_image_url')->toArray();
+
+        foreach ($profileImageUrlWithIds as $profileImageUrlWithId) {
+
+            $url = $profileImageUrlWithId['profile_image_url'];
+            $user_id = $profileImageUrlWithId['id'];
+
+            if ($url){
+
+                $this->imageService->downloadImageFromUrl($url, $user_id);
+            }
+
+        }
 
         $this->info('All profile image urls on Users table are now downloaded, with entries added to the Images table.');
     }

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -13,6 +13,7 @@ class Image extends Model
     protected $fillable = [
         'filename',
         'image_role',
+        'user_id',
     ];
 
     public function user(): BelongsTo

--- a/app/Service/ImageService.php
+++ b/app/Service/ImageService.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Service;
+
+use App\Models\Image;
+use Illuminate\Support\Str;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use App\Models\User;
+
+class ImageService
+{
+
+    public function createFilename($id){
+        //Gets the ID and assigns it the name 'user-profile-#'. Returns new filename.
+        $filename = "user-profile-{$id}";
+        return($filename);
+    }
+
+    public function assignImage($destinationPath, $id){
+        // Takes the file path and id and creates an image record in the Images table
+        Image::updateOrCreate(
+            ['user_id' => $id],
+            [
+                'filename' => $destinationPath,
+                'image_role' => 'profile'
+            ]
+        );
+    }
+
+    public function downloadUrls($profileImageUrl, $id){
+
+        //Get the image contents of the profile image url. If there are none, throw error.
+        $imageContent = file_get_contents($profileImageUrl);
+        if($imageContent === false)
+            {
+                throw new \Exception("Could not access image from URL.");
+
+            }
+
+        //Get the extension of the profile image url.
+        $extension = pathinfo($profileImageUrl)['extension'];
+
+        //Run the createFilename method against the id to create a unique filename. Gets the new filename as $newFilename
+        $newFilename = $this->createFilename($id);
+
+        //Combines the new filename with the extension.
+        $finalFilename = "{$newFilename}.{$extension}";
+
+        //Uses $finalFilename to construct the full path link. If either the path or data don't exist, throw error.
+        $destinationPath = 'profile-images/' . $finalFilename;
+
+        //Tries to store the file into the profile-images folder. If it can't, it logs an error.
+        try{
+            Storage::disk('public')->put($destinationPath, $imageContent);
+        } catch(\Throwable $e) {
+            \Log::info('Image failed to download.');
+        }
+
+        //Return the file path (to be used in assignImage)
+        $this->assignImage($destinationPath, $id);
+
+    }
+
+    public function copyAllUserProfileImageUrls(){
+
+        //Goes and grabs all users and makes an array with id and profile_image_url
+        $profileImageUrlWithIds = User::all()->map->only('id', 'profile_image_url')->toArray();
+
+        foreach ($profileImageUrlWithIds as $profileImageUrlWithId) {
+            //For this instance, assign the current profile_image_url and id to variables
+            $profileImageUrl = $profileImageUrlWithId['profile_image_url'];
+            $id = $profileImageUrlWithId['id'];
+
+            //If profile_image_url is not null, run the following. Otherwise go to next record.
+            if ($profileImageUrl){
+
+                //Call 'downloadUrls' method to download URLs.
+                $this->downloadUrls($profileImageUrl, $id);
+            }
+
+        }
+    }
+
+}

--- a/app/Service/ImageService.php
+++ b/app/Service/ImageService.php
@@ -3,84 +3,52 @@
 namespace App\Service;
 
 use App\Models\Image;
-use Illuminate\Support\Str;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
-use App\Models\User;
 
 class ImageService
 {
 
-    public function createFilename($id){
-        //Gets the ID and assigns it the name 'user-profile-#'. Returns new filename.
-        $filename = "user-profile-{$id}";
-        return($filename);
-    }
+    public function downloadImageFromUrl($url, $user_id){
 
-    public function assignImage($destinationPath, $id){
-        // Takes the file path and id and creates an image record in the Images table
-        Image::updateOrCreate(
-            ['user_id' => $id],
-            [
-                'filename' => $destinationPath,
-                'image_role' => 'profile'
-            ]
-        );
-    }
-
-    public function downloadUrls($profileImageUrl, $id){
-
-        //Get the image contents of the profile image url. If there are none, throw error.
-        $imageContent = file_get_contents($profileImageUrl);
+        $imageContent = file_get_contents($url);
         if($imageContent === false)
             {
                 throw new \Exception("Could not access image from URL.");
 
             }
 
-        //Get the extension of the profile image url.
-        $extension = pathinfo($profileImageUrl)['extension'];
+        $basename = pathinfo($url)['basename'];
 
-        //Run the createFilename method against the id to create a unique filename. Gets the new filename as $newFilename
-        $newFilename = $this->createFilename($id);
-
-        //Combines the new filename with the extension.
-        $finalFilename = "{$newFilename}.{$extension}";
-
-        //Uses $finalFilename to construct the full path link. If either the path or data don't exist, throw error.
-        $destinationPath = 'profile-images/' . $finalFilename;
-
-        //Tries to store the file into the profile-images folder. If it can't, it logs an error.
         try{
-            Storage::disk('public')->put($destinationPath, $imageContent);
+            Storage::disk('public')->put($basename, $imageContent);
         } catch(\Throwable $e) {
             \Log::info('Image failed to download.');
         }
 
-        //Return the file path (to be used in assignImage)
-        $this->assignImage($destinationPath, $id);
+        $this->createUserImage($basename, $user_id);
 
     }
 
-    public function copyAllUserProfileImageUrls(){
+    public function createUserImage($basename, $user_id){
 
-        //Goes and grabs all users and makes an array with id and profile_image_url
-        $profileImageUrlWithIds = User::all()->map->only('id', 'profile_image_url')->toArray();
-
-        foreach ($profileImageUrlWithIds as $profileImageUrlWithId) {
-            //For this instance, assign the current profile_image_url and id to variables
-            $profileImageUrl = $profileImageUrlWithId['profile_image_url'];
-            $id = $profileImageUrlWithId['id'];
-
-            //If profile_image_url is not null, run the following. Otherwise go to next record.
-            if ($profileImageUrl){
-
-                //Call 'downloadUrls' method to download URLs.
-                $this->downloadUrls($profileImageUrl, $id);
-            }
-
+        $userDirectory = storage_path("app/public/user-{$user_id}");
+        if (!file_exists($userDirectory)) {
+            mkdir($userDirectory, 0755, true);
         }
+
+        $newFilepath = storage_path("app/public/user-{$user_id}/{$basename}");
+        $oldFilepath = storage_path("app/public/{$basename}");
+        $symbolicFilepath = "user-{$user_id}/{$basename}";
+
+        rename($oldFilepath,$newFilepath);
+
+        Image::updateOrCreate(
+            ['user_id' => $user_id],
+            [
+                'filename' => $symbolicFilepath,
+                'image_role' => 'profile'
+            ]
+        );
     }
 
 }


### PR DESCRIPTION
Created ImageService that takes the profile_image_url column of the User's table, iterates and copies all existing URLs, downloads the images to the profile-images folder under public directory, assigns a unique filename with the user id, and adds new records in the Images table with those associations. A CopyProfileImageUrls command was created to run ImageService though the console.

Also made user_id in the Images table fillable.