### PR TITLE
Drop User Profile Image URL Column Migration

### DIFF
--- a/database/migrations/2024_09_25_154222_drop_user_profile_image_url_column.php
+++ b/database/migrations/2024_09_25_154222_drop_user_profile_image_url_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('profile_image_url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('profile_image_url');
+        });
+    }
+};


### PR DESCRIPTION
Drop profile_image_url column via migration for users since it is no longer being used to provide paths for profile images.