### PR TITLE
Profile Image Upload on User Registration

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use App\Service\ImageService;
 use Illuminate\Validation\Rules;
 use App\Http\Controllers\Controller;
+use Exception;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Hash;
@@ -60,10 +61,10 @@ class RegisteredUserController extends Controller
                 $fileContents = $request->profile_image->get();
                 $path = $request->file('profile_image')->storeAs($folder, $filename, 'public');
 
-
                 if(!Storage::disk('public')->put($path, $fileContents))
                 {
-                    return redirect()->back()->withErrors(['profile_image' => 'Image upload failed.']);
+                    throw new Exception('Image upload failed.');
+
                 }
 
                 $imageService->addUserImageRecord($user->id, $path);
@@ -74,10 +75,10 @@ class RegisteredUserController extends Controller
 
                 return redirect(route('dashboard', absolute: false));
 
-            } catch(\Throwable $e) {
+            } catch(Exception $e) {
 
-                \Log::info('Image failed to download.');
-                return redirect()->back();
+                \Log::info($e->getMessage());
+                return redirect()->back()->withErrors(['profile_image' => $e->getMessage()]);
 
             }
 

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -2,15 +2,19 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Http\Controllers\Controller;
 use App\Models\User;
-use Illuminate\Auth\Events\Registered;
-use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Validation\Rules;
 use Illuminate\View\View;
+use Illuminate\Http\Request;
+use App\Service\ImageService;
+use Illuminate\Validation\Rules;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class RegisteredUserController extends Controller
 {
@@ -27,23 +31,49 @@ class RegisteredUserController extends Controller
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request, ImageService $imageService): RedirectResponse
     {
+
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
-            'profile_image_url' => ['string','url', 'max:255', 'nullable']
+            'profile_image' => ['nullable', 'image', 'mimes:jpeg,png,jpg,gif', 'max:2048'],
         ]);
 
         $user = User::create([
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
-            'profile_image_url' => $request->profile_image_url ?? 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png'
         ]);
 
         event(new Registered($user));
+
+        if($request->profile_image && $request->profile_image->extension()){
+
+            $success = false;
+
+            $extension = $request->profile_image->extension();
+            $filename = "profile-image" . '.' . $extension;
+            $folder = "user-{$user->id}";
+            $path = $folder . '/' . $filename;
+            $fileContents = $request->profile_image->get();
+            $path = $request->file('profile_image')->storeAs($folder, $filename, 'public');
+
+            try{
+                $success = Storage::disk('public')->put($path, $fileContents);
+            } catch(\Throwable $e) {
+                \Log::info('Image failed to download.');
+            }
+
+            if($success) {
+                $imageService->addUserImageRecord($user->id, $path);
+            } else {
+                return redirect()->back()->withErrors(['profile_image' => 'Image upload failed.']);
+            }
+
+        }
+
 
         Auth::login($user);
 

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -78,7 +78,7 @@ class RegisteredUserController extends Controller
             } catch(Exception $e) {
 
                 \Log::info($e->getMessage());
-                return redirect()->back()->withErrors(['profile_image' => $e->getMessage()]);
+                return redirect()->back()->withErrors(['generic' => $e->getMessage()]);
 
             }
 

--- a/app/View/Components/Chirps/ChirpCard.php
+++ b/app/View/Components/Chirps/ChirpCard.php
@@ -12,7 +12,6 @@ class ChirpCard extends Component
     public $chirp;
     public $name;
     public $id;
-    public $profileImageUrl;
     public $message;
     public $chirpCreatedDate;
 
@@ -29,10 +28,6 @@ class ChirpCard extends Component
         // Assign User's ID
         $id = $chirp->user->id;
         $this->id = $id;
-
-        // Assign Profile Image URL
-        $profileImageUrl = $chirp->user->profile_image_url;
-        $this->profileImageUrl = $profileImageUrl;
 
         // Assign Message
         $message = $chirp->message;

--- a/app/View/Components/UserCard.php
+++ b/app/View/Components/UserCard.php
@@ -17,7 +17,6 @@ class UserCard extends Component
     public $user;
     public $id;
     public $name;
-    public $profileImageUrl;
     public $userChirpsCount;
     public $firstChirpDate;
     /**
@@ -32,10 +31,6 @@ class UserCard extends Component
         // Assign User's ID
         $id = $user->id;
         $this->id = $id;
-
-        // Assign Profile Image URL
-        $profileImageUrl = $user->profile_image_url;
-        $this->profileImageUrl = $profileImageUrl;
 
         // Assign Chirps Count
         $userChirpsCount = $user->chirps_count;

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -56,5 +56,8 @@
                 {{ __('Register') }}
             </x-primary-button>
         </div>
+
+        <x-input-error :messages="$errors->get('generic')" class="mt-2" />
+
     </form>
 </x-guest-layout>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,5 +1,5 @@
 <x-guest-layout>
-    <form method="POST" action="{{ route('register') }}">
+    <form method="POST" action="{{ route('register') }}" enctype="multipart/form-data">
         @csrf
 
         <!-- Name -->
@@ -42,9 +42,9 @@
         <!-- Optional Profile Image -->
 
         <div class="mt-4">
-            <x-input-label for="profile_image_url" :value="__('Profile Image URL (Optional)')" />
-            <x-text-input id="profile_image_url" class="block mt-1 w-full" type="text" name="profile_image_url" :value="old('profile_image_url')"/>
-            <x-input-error :messages="$errors->get('profile_image_url')" class="mt-2" />
+            <x-input-label for="profile_image" :value="__('Profile Image (Optional)')" />
+            <input id="profile_image" name="profile_image" type="file" class="block mt-1 w-full">
+            <x-input-error :messages="$errors->get('profile_image')" class="mt-2" />
         </div>
 
         <div class="flex items-center justify-end mt-4">


### PR DESCRIPTION
Adjusted the user register form to take an image upload. The store method for RegisteredUserController validates an optional profile image and after the user is created, it checks if an image was included and has a proper extension. After that, it creates a unique folder inside public connected to the user-id, renames the file to 'profile-image', and downloads the image to that directory. If everything is successful, a record is added to the Images table with the newly created user's id, image path, and role via the addUserImageRecord method in the ImageService.

Removed deprecated references to profileImageUrl in several files.