### PR TITLE
Fix Foreign Key Constraint with Migration

### DIFF
--- a/database/migrations/2024_10_02_123240_drop_images_table_user_id_and_image_role_columns.php
+++ b/database/migrations/2024_10_02_123240_drop_images_table_user_id_and_image_role_columns.php
@@ -12,6 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('images', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
             $table->dropColumn('user_id');
             $table->dropColumn('image_role');
         });
@@ -26,5 +27,6 @@ return new class extends Migration
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('image_role')->nullable();
         });
+
     }
 };


### PR DESCRIPTION
Changed the migration to drop the foreign key constraint before dropping the user_id column so it runs.