### PR TITLE
Delete User Image

### DIFF
--- a/app/Http/Controllers/UserImageController.php
+++ b/app/Http/Controllers/UserImageController.php
@@ -62,10 +62,10 @@ class UserImageController extends Controller
                 throw new \Exception("There is no image to delete.");
             }
 
-            $deleteImageFromDir = $imageService->deleteImageFromDirectory($userImage->filename);
+            $userImageFileDeleteStatus = $imageService->deleteFileAtPath($userImage->filename);
 
-            if ($deleteImageFromDir === false){
-                throw new \Exception("There is no image in the user's directory, but an image record still exists.");
+            if ($userImageFileDeleteStatus === false){
+                throw new \Exception("There is still a user-image in the user's image directory after attempting to delete.");
             }
 
             $userImage->delete();

--- a/app/Http/Controllers/UserImageController.php
+++ b/app/Http/Controllers/UserImageController.php
@@ -13,10 +13,6 @@ use App\Service\ImageService;
 
 class UserImageController extends Controller
 {
-    public function index()
-    {
-
-    }
 
     public function store(Request $request, ImageService $imageService): RedirectResponse
     {
@@ -55,19 +51,33 @@ class UserImageController extends Controller
 
     }
 
-    public function edit()
+
+    public function destroy(ImageService $imageService): RedirectResponse
     {
+        try{
 
-    }
+            $userImage = Auth::user()->images->first();
 
-    public function update()
-    {
+            if (!$userImage) {
+                throw new \Exception("There is no image to delete.");
+            }
 
-    }
+            $deleteImageFromDir = $imageService->deleteImageFromDirectory($userImage->filename);
 
+            if ($deleteImageFromDir === false){
+                throw new \Exception("There is no image in the user's directory, but an image record still exists.");
+            }
 
-    public function destroy()
-    {
+            $userImage->delete();
+
+            return redirect(route('profile.edit', absolute: false));
+
+        } catch(\Throwable $e) {
+
+            \Log::info($e->getMessage());
+            return redirect()->back()->withErrors(['user_image_delete' => $e->getMessage()]);
+
+        }
 
     }
 }

--- a/app/Service/ImageService.php
+++ b/app/Service/ImageService.php
@@ -2,11 +2,12 @@
 
 namespace App\Service;
 
+use Exception;
 use App\Models\User;
 use App\Models\Image;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
-use Exception;
 
 class ImageService
 {
@@ -113,6 +114,19 @@ class ImageService
             return false;
         }
 
+        return true;
+
+    }
+
+    //Test by deleting an image. Takes in string 'user-#/user-image.ext'. Returns true/false if file exists.
+    public function deleteImageFromDirectory($publicPath){
+
+        $filePath = storage_path("app/public/{$publicPath}");
+        if(!File::exists($filePath))
+        {
+            return false;
+        }
+        File::delete($filePath);
         return true;
 
     }

--- a/app/Service/ImageService.php
+++ b/app/Service/ImageService.php
@@ -118,15 +118,21 @@ class ImageService
 
     }
 
-    //Test by deleting an image. Takes in string 'user-#/user-image.ext'. Returns true/false if file exists.
-    public function deleteImageFromDirectory($publicPath){
+
+    /**
+     * @param string Takes in image path name as 'user-#/user-image.ext'.
+     * Attempts to delete image from directory.
+     * @return bool Returns true if the file is successfully deleted. Returns false if the file is still present in the directory.
+     */
+
+    public function deleteFileAtPath($publicPath){
 
         $filePath = storage_path("app/public/{$publicPath}");
-        if(!File::exists($filePath))
+        File::delete($filePath);
+        if(File::exists($filePath))
         {
             return false;
         }
-        File::delete($filePath);
         return true;
 
     }

--- a/resources/views/profile/partials/update-profile-picture-form.blade.php
+++ b/resources/views/profile/partials/update-profile-picture-form.blade.php
@@ -18,13 +18,24 @@
 
     <form method="POST" action="{{ route('user-image.store') }}" enctype="multipart/form-data">
         @csrf
-        <input id="user_image" name="user_image" type="file" class="block mt-1 w-full">
+        <input id="user_image" name="user_image" type="file" class="block mt-1 w-full" required>
         <x-input-error :messages="$errors->get('user_image')" class="mt-2" />
 
         <div class="mt-4">
             <x-primary-button style="background-color:rgb(38, 167, 222);">
                 {{ __('Upload/Replace') }}
             </x-primary-button>
+        </div>
+    </form>
+
+    <form method="POST" action="{{ route('user-image.destroy') }}">
+        @csrf
+        @method('delete')
+        <div class="mt-4">
+            <x-primary-button class="inline-flex items-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-500 active:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                {{ __('Delete') }}
+            </x-primary-button>
+            <x-input-error :messages="$errors->get('user_image_delete')" class="mt-2" />
         </div>
 
     </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,7 +53,7 @@ Route::group(['middleware' => ['auth']], function(){
 
 Route::group(['middleware' => ['auth']], function(){
     Route::post('user-image/', [UserImageController::class, 'store'])->name('user-image.store');
-    Route::delete('user-image/{id}', [UserImageController::class, 'destroy'])->name('user-image.destroy');
+    Route::delete('user-image/', [UserImageController::class, 'destroy'])->name('user-image.destroy');
 
 });
 


### PR DESCRIPTION
Updated destroy method on UserImageController to get the users image, check for it, use the new deleteImageFromDirectory method in ImageService to check for and delete the file, and delete the user's user-image (which also removes the record in the pivot table). Added form and form button for the destroy route that handles the deletion of a user image.