### PR TITLE
Updated ChirpController Update & Destroy Methods. New ImageService Methods.  Updated UserImageController Store Method with ImageService Methods. Updated Views.

### DIFF
--- a/app/Http/Controllers/ChirpController.php
+++ b/app/Http/Controllers/ChirpController.php
@@ -131,16 +131,23 @@ class ChirpController extends Controller
                 $basename = "chirp-{$chirp->id}-image";
                 $filename = $basename . '.' . $extension;
 
-                $redundantFilesStatus = $imageService->deleteRedundantFilesAtPath($folder, $basename);
+                //Checks if there is an old image record.
+                $oldImageRecord = $chirp->images->first();
 
-                if($redundantFilesStatus === false){
-                    throw new Exception("The old chirp images were not deleted from the directory properly.");
-                }
+                if($oldImageRecord){
 
-                $redundantImageRecordsStatus = $imageService->deleteRedundantImageRecords($folder, $basename);
+                    //Deletes Last File in Dir for Chirp Image
+                    $oldImageDirStatus = $imageService->deleteFileAtPath($oldImageRecord->filename);
+                    if($oldImageDirStatus === false){
+                        throw new Exception("Last chirp image file was not deleted properly.");
+                    }
 
-                if($redundantImageRecordsStatus === false){
-                    throw new Exception("The old chirp images records were not deleted properly.");
+                    //Delete Last Image Record For Chirp Image
+                    $oldImageRecordStatus = $imageService->deleteImageRecord($oldImageRecord);
+                    if($oldImageRecordStatus === false){
+                        throw new Exception("Last chirp image record was not deleted properly.");
+                    }
+
                 }
 
                 $image = $imageService->uploadImage($uploadedFile, $folder, $filename);

--- a/app/Http/Controllers/ChirpController.php
+++ b/app/Http/Controllers/ChirpController.php
@@ -44,20 +44,16 @@ class ChirpController extends Controller
             'message' => 'required|string|max:255',
         ]);
 
-        //If the image isn't a valid one.
         if($request->chirp_image && exif_imagetype($request->chirp_image) === false){
             throw new \Exception("The image is not valid.");
         }
 
-        //Submit the chirp without the image first (so I can get the Chirp ID)
         $submittedChirp = $request->user()->chirps()->create($validated);
 
-        //If the chirp wasn't created.
         if(!$submittedChirp){
             throw new \Exception("The chirp couldn't be submitted.");
         }
 
-        //If there is an image do this, otherwise continue the text chirp.
         if($request->chirp_image){
 
             $uploadedFile = $request->chirp_image;
@@ -105,29 +101,101 @@ class ChirpController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Chirp $chirp): RedirectResponse
+    public function update(Request $request, Chirp $chirp, ImageService $imageService): RedirectResponse
     {
-        Gate::authorize('update', $chirp);
 
-        $validated = $request->validate([
-            'message' => 'required|string|max:255'
-        ]);
+        try{
 
-        $chirp->update($validated);
+            Gate::authorize('update', $chirp);
 
-        return redirect(route('chirps.index'));
+            $validated = $request->validate([
+                'message' => 'required|string|max:255',
+            ]);
+
+
+            if($request->chirp_image && exif_imagetype($request->chirp_image) === false){
+                throw new \Exception("The image is not valid.");
+            }
+
+            $chirp->update($validated);
+
+            if(!$chirp){
+                throw new \Exception("The chirp could not be updated.");
+            }
+
+            if($request->chirp_image){
+
+                $uploadedFile = $request->chirp_image;
+                $folder = $imageService->getUserFolder($request->user());
+                $extension = $uploadedFile->extension();
+                $basename = "chirp-{$chirp->id}-image";
+                $filename = $basename . '.' . $extension;
+
+                $redundantFilesStatus = $imageService->deleteRedundantFilesAtPath($folder, $basename);
+
+                if($redundantFilesStatus === false){
+                    throw new Exception("The old chirp images were not deleted from the directory properly.");
+                }
+
+                $redundantImageRecordsStatus = $imageService->deleteRedundantImageRecords($folder, $basename);
+
+                if($redundantImageRecordsStatus === false){
+                    throw new Exception("The old chirp images records were not deleted properly.");
+                }
+
+                $image = $imageService->uploadImage($uploadedFile, $folder, $filename);
+
+                $chirp->images()->sync([$image->id]);
+
+
+            }
+
+            return redirect(route('chirps.index'));
+
+
+            } catch(Exception $e){
+                \Log::info($e->getMessage());
+                return redirect()->back()->withErrors(['message' => $e->getMessage()]);
+            }
+
+
     }
+
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Chirp $chirp): RedirectResponse
+    public function destroy(Chirp $chirp, ImageService $imageService): RedirectResponse
     {
+        try{
+
         Gate::authorize('delete', $chirp);
+
+        $chirpImage = $chirp->images->first();
+
+        if($chirpImage){
+
+            $chirpImageFileDeleteStatus = $imageService->deleteFileAtPath($chirpImage->filename);
+
+            if ($chirpImageFileDeleteStatus === false){
+                throw new \Exception("There is still a chirp-image in the user's image directory after attempting to delete.");
+            }
+
+            $chirpImage->delete();
+
+        }
 
         $chirp->delete();
 
         return redirect(route('chirps.index'));
+
+
+        } catch(\Throwable $e) {
+            \Log::info($e->getMessage());
+            //Find place where the error shows up in view
+            return redirect()->back()->withErrors(['message' => $e->getMessage()]);
+
+        }
     }
 
 }

--- a/app/Http/Controllers/ChirpController.php
+++ b/app/Http/Controllers/ChirpController.php
@@ -137,14 +137,12 @@ class ChirpController extends Controller
                 if($oldImageRecord){
 
                     //Deletes Last File in Dir for Chirp Image
-                    $oldImageDirStatus = $imageService->deleteFileAtPath($oldImageRecord->filename);
-                    if($oldImageDirStatus === false){
+                    if($imageService->deleteFileAtPath($oldImageRecord->filename) === false){
                         throw new Exception("Last chirp image file was not deleted properly.");
                     }
 
                     //Delete Last Image Record For Chirp Image
-                    $oldImageRecordStatus = $imageService->deleteImageRecord($oldImageRecord);
-                    if($oldImageRecordStatus === false){
+                    if($imageService->deleteImageRecord($oldImageRecord) === false){
                         throw new Exception("Last chirp image record was not deleted properly.");
                     }
 

--- a/app/Http/Controllers/UserImageController.php
+++ b/app/Http/Controllers/UserImageController.php
@@ -34,16 +34,23 @@ class UserImageController extends Controller
                 $basename = 'user-image';
                 $filename = $basename . '.' . $extension;
 
-                $redundantFilesStatus = $imageService->deleteRedundantFilesAtPath($folder, $basename);
+                //Checks if there is an old image record.
+                $oldImageRecord = $user->images->first();
 
-                if($redundantFilesStatus === false){
-                    throw new Exception("The old user images were not deleted from the directory properly.");
-                }
+                if($oldImageRecord){
 
-                $redundantImageRecordsStatus = $imageService->deleteRedundantImageRecords($folder, $basename);
+                    //Deletes Last File in Dir for User Image
+                    $oldImageDirStatus = $imageService->deleteFileAtPath($oldImageRecord->filename);
+                    if($oldImageDirStatus === false){
+                        throw new Exception("Last user image file was not deleted properly.");
+                    }
 
-                if($redundantImageRecordsStatus === false){
-                    throw new Exception("The old user images records were not deleted properly.");
+                    //Delete Last Image Record For User Image
+                    $oldImageRecordStatus = $imageService->deleteImageRecord($oldImageRecord);
+                    if($oldImageRecordStatus === false){
+                        throw new Exception("Last user image record was not deleted properly.");
+                    }
+
                 }
 
                 $image = $imageService->uploadImage($uploadedFile, $folder, $filename);

--- a/app/Http/Controllers/UserImageController.php
+++ b/app/Http/Controllers/UserImageController.php
@@ -40,14 +40,13 @@ class UserImageController extends Controller
                 if($oldImageRecord){
 
                     //Deletes Last File in Dir for User Image
-                    $oldImageDirStatus = $imageService->deleteFileAtPath($oldImageRecord->filename);
-                    if($oldImageDirStatus === false){
+
+                    if($imageService->deleteFileAtPath($oldImageRecord->filename) === false){
                         throw new Exception("Last user image file was not deleted properly.");
                     }
 
                     //Delete Last Image Record For User Image
-                    $oldImageRecordStatus = $imageService->deleteImageRecord($oldImageRecord);
-                    if($oldImageRecordStatus === false){
+                    if($imageService->deleteImageRecord($oldImageRecord) === false){
                         throw new Exception("Last user image record was not deleted properly.");
                     }
 

--- a/app/Service/ImageService.php
+++ b/app/Service/ImageService.php
@@ -56,6 +56,24 @@ class ImageService
     }
 
 
+
+    /**
+     * @param image Takes in the current image connected to the other model.
+     * Attempts to delete image from directory.
+     * @return bool Returns true if the file is successfully deleted. Returns false if the file is still exists.
+     */
+    public function deleteImageRecord($imageRecord){
+
+        $imageRecord->delete();
+
+        if($imageRecord->exists === true){
+            return false;
+        }
+
+        return true;
+    }
+
+
     public function uploadImage($uploadedFile, $folder, $filename){
 
         if(!$uploadedFile->storeAs($folder, $filename, 'public'))
@@ -133,44 +151,6 @@ class ImageService
         {
             return false;
         }
-        return true;
-
-    }
-
-    public function deleteRedundantFilesAtPath($folder, $basename){
-
-        $pattern = storage_path("app/public/{$folder}/{$basename}.*");
-        $files = glob($pattern);
-
-        if($files){
-            File::delete(File::glob(storage_path("app/public/{$folder}/{$basename}*.*")));
-        }
-
-        //If there are still images of that filename in the directory.
-        if(!count($files) === 0){
-            return false;
-        }
-
-        return true;
-
-    }
-
-    public function deleteRedundantImageRecords($folder, $basename){
-        $filenameString = "{$folder}/{$basename}";
-        $oldUserImages = Image::where('filename', 'LIKE', "%{$filenameString}%")->get();
-
-        if($oldUserImages){
-            foreach ($oldUserImages as $oldUserImage){
-                $oldUserImage->delete();
-            }
-
-        }
-
-        //If there are still records in the images table with that filename substring.
-        if(!count($oldUserImages) === 0){
-            return false;
-        }
-
         return true;
 
     }

--- a/app/Service/ImageService.php
+++ b/app/Service/ImageService.php
@@ -137,4 +137,42 @@ class ImageService
 
     }
 
+    public function deleteRedundantFilesAtPath($folder, $basename){
+
+        $pattern = storage_path("app/public/{$folder}/{$basename}.*");
+        $files = glob($pattern);
+
+        if($files){
+            File::delete(File::glob(storage_path("app/public/{$folder}/{$basename}*.*")));
+        }
+
+        //If there are still images of that filename in the directory.
+        if(!count($files) === 0){
+            return false;
+        }
+
+        return true;
+
+    }
+
+    public function deleteRedundantImageRecords($folder, $basename){
+        $filenameString = "{$folder}/{$basename}";
+        $oldUserImages = Image::where('filename', 'LIKE', "%{$filenameString}%")->get();
+
+        if($oldUserImages){
+            foreach ($oldUserImages as $oldUserImage){
+                $oldUserImage->delete();
+            }
+
+        }
+
+        //If there are still records in the images table with that filename substring.
+        if(!count($oldUserImages) === 0){
+            return false;
+        }
+
+        return true;
+
+    }
+
 }

--- a/resources/views/chirps/edit.blade.php
+++ b/resources/views/chirps/edit.blade.php
@@ -1,8 +1,18 @@
 <x-app-layout>
     <div class="max-w-2xl mx-auto p-4 sm:p-6 lg:p-8">
-        <form method="POST" action="{{ route('chirps.update', $chirp) }}">
+        <form method="POST" action="{{ route('chirps.update', $chirp) }}" enctype="multipart/form-data">
             @csrf
             @method('PUT')
+            <p class="pb-2">Current Image:</p>
+
+            @empty($chirp->images->first()->filename)
+            @else
+            <img src="{{asset('storage/'.$chirp->images->first()->filename)}}" style="max-width:300px;">
+            @endif
+
+            <p class="pt-2">Upload/Replace Image:</p>
+            <input id="chirp_image" name="chirp_image" type="file" class="block mt-1 w-full py-2">
+
             <textarea
                 name="message"
                 class="block w-full border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm"

--- a/resources/views/components/chirps/chirp-box.blade.php
+++ b/resources/views/components/chirps/chirp-box.blade.php
@@ -1,4 +1,8 @@
-<details>
+    @if (request()->routeIs('chirps.index') || request()->routeIs('dashboard'))
+    <details open>
+    @else
+    <details>
+    @endif
     <summary class="chirpToggle">Click Here to Chirp Something!</summary>
     <div class="bg-white rounded-lg shadow-sm p-4 my-5 fixed right-0 bottom-9 w-[400px] z-10">
         <form method="POST" action="{{ route('chirps.store') }}" enctype="multipart/form-data">

--- a/resources/views/components/chirps/chirp-card.blade.php
+++ b/resources/views/components/chirps/chirp-card.blade.php
@@ -19,7 +19,7 @@
 
                     @empty($chirp->images->first()->filename)
                     @else
-                    <img src="{{asset('storage/'.$chirp->images->first()->filename)}}">
+                    <img src="{{asset('storage/'.$chirp->images->first()->filename)}}" class="rounded-md">
                     @endif
 
                     <p class="mt-4 text-m text-gray-600">" {{ $message }} "</p>


### PR DESCRIPTION
Updated Chirp Image update and destroy methods. Update now allows the user to swap out the image while editing a chirp, and destroy goes and deletes the image from the folder and image record. Two methods have been created, 
 deleteRedundantFilesAtPath and deleteRedundantImageRecords. The purpose of these was to delete duplicate files and records where the extensions were different. They go in and check if there are files/records with the same name and deletes them before replacing/uploading. I've included these when editing a chirp and uploading/replacing a user image. Updated the views to accommodate the new changes.